### PR TITLE
Fix: Ensure compatibility with Psycopg 3 by updating server_version access

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='django-pg-bulk-update',
-    version='3.7.2',
+    version='3.7.3',
     packages=['django_pg_bulk_update'],
     package_dir={'': 'src'},
     url='https://github.com/M1hacka/django-pg-bulk-update',

--- a/src/django_pg_bulk_update/compatibility.py
+++ b/src/django_pg_bulk_update/compatibility.py
@@ -163,7 +163,12 @@ def get_postgres_version(using=None, as_tuple=True):
         A single number major*10000 + minor*100 + revision if false.
     """
     conn = connection if using is None else connections[using]
-    num = conn.cursor().connection.server_version
+    try:
+        # server_version moved to ConnectionInfo class in psycopg 3.0
+        num = conn.cursor().connection.info.server_version
+    except AttributeError:
+        # server_version is directly available in the Connection class in psycopg 2.x
+        num = conn.cursor().connection.server_version
     return (int(num / 10000), int(num % 10000 / 100), num % 100) if as_tuple else num
 
 


### PR DESCRIPTION
As documented in [psycopg3 docs](https://www.psycopg.org/psycopg3/docs/api/objects.html#psycopg.ConnectionInfo.server_version)